### PR TITLE
Update pom.xml

### DIFF
--- a/roncoo-education-app-job/pom.xml
+++ b/roncoo-education-app-job/pom.xml
@@ -51,6 +51,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
job工程的pom文件少了spring-cloud-starter-netflix-hystrix， 启动会报错 @EnableCircuitBreaker found, but there are no implementations. Did you forget to include a starter?